### PR TITLE
modify to accomodate perl 5.12 and later undef handling to quell Warn…

### DIFF
--- a/BeanCounter.pm
+++ b/BeanCounter.pm
@@ -1614,14 +1614,8 @@ sub ParseDailyData {		# stuff the output into the hash
 
 
 sub ParseNumeric {		# parse numeric fields which could be fractions
-# 
-#	try to quell: 
-#	Use of uninitialized value $v in substitution (s///) 
-#	at /usr/share/perl5/vendor_perl/Finance/BeanCounter.pm line 1618
-#
       my $v = 0 ;
   $v = shift;		# expect one argument
-  # comfort perl >= 5.12 and later
   if (! defined $v) { $v = 0 ;} 
   $v =~ s/\s*$//;		# kill trailing whitespace
   $v =~ s/\+//;			# kill leading plus sign
@@ -1746,15 +1740,11 @@ sub ScrubDailyData {          # stuff the output into the hash
 
     if ($hash{$key}{date} ne $Config{today}) {   # if date is not today
 
-#	try to quell undef noise:
-#		Use of uninitialized value $age in numeric gt (>) \
-#			at /usr/share/perl5/vendor_perl/Finance/BeanCounter.pm line 1743
       my $age = 6 ;
       #Delta_Format($Config{today}, $Config{lastbizday},
       #                              undef, 2), "approx", 0, "%dt");
       $age = Delta_Format(DateCalc($hash{$key}{date}, $Config{lastbizday},
 				      undef, 2), "approx", 0, "%dt");
-# comfort perl >= 5.12 and later
       if (! defined $age ) { $age = 6 ; }
       if ($age > 5) {
         warn "Ignoring $hash{$key}{symbol} ($hash{$key}{name}) " .

--- a/BeanCounter.pm
+++ b/BeanCounter.pm
@@ -1614,7 +1614,15 @@ sub ParseDailyData {		# stuff the output into the hash
 
 
 sub ParseNumeric {		# parse numeric fields which could be fractions
-  my $v = shift;		# expect one argument
+# 
+#	try to quell: 
+#	Use of uninitialized value $v in substitution (s///) 
+#	at /usr/share/perl5/vendor_perl/Finance/BeanCounter.pm line 1618
+#
+      my $v = 0 ;
+  $v = shift;		# expect one argument
+  # comfort perl >= 5.12 and later
+  if (! defined $v) { $v = 0 ;} 
   $v =~ s/\s*$//;		# kill trailing whitespace
   $v =~ s/\+//;			# kill leading plus sign
   if ($v =~ m|(.*) (.*)/(.*)|) {# if it is a fraction
@@ -1738,8 +1746,16 @@ sub ScrubDailyData {          # stuff the output into the hash
 
     if ($hash{$key}{date} ne $Config{today}) {   # if date is not today
 
-      my $age = Delta_Format(DateCalc($hash{$key}{date}, $Config{lastbizday},
+#	try to quell undef noise:
+#		Use of uninitialized value $age in numeric gt (>) \
+#			at /usr/share/perl5/vendor_perl/Finance/BeanCounter.pm line 1743
+      my $age = 6 ;
+      #Delta_Format($Config{today}, $Config{lastbizday},
+      #                              undef, 2), "approx", 0, "%dt");
+      $age = Delta_Format(DateCalc($hash{$key}{date}, $Config{lastbizday},
 				      undef, 2), "approx", 0, "%dt");
+# comfort perl >= 5.12 and later
+      if (! defined $age ) { $age = 6 ; }
       if ($age > 5) {
         warn "Ignoring $hash{$key}{symbol} ($hash{$key}{name}) " .
 	  "with old date $hash{$key}{date}\n";

--- a/beancounter
+++ b/beancounter
@@ -399,9 +399,12 @@ sub display_longstatus {
   foreach my $key (sort keys %value) {
     my ($name,$count) = split /:/, $key;
     my $value = $value{$key};
-    my ($daysheld,$return,$fxthen,$fxnow) = ("", "", 1.0, 1.0);
+# daysheld default can be a zero, to amake perl >= 5.12 happier
+    my ($daysheld,$return,$fxthen,$fxnow) = (0, "", 1.0, 1.0);
     if (defined($pdate->{$key})) { # if we have a purchase date
       $daysheld = Delta_Format(DateCalc($pdate->{$key}, $date, \$err, 2), "approx", 0, "%dt");
+#	comfort perl >= 5.12
+      if (! defined $daysheld ) {$daysheld = 0 ; }
       if (defined($cost->{$key}) and $daysheld >= 0 and $cost->{$key} != 0) {
 	if ($fx->{$name} ne $Config{currency}) {
 	  $fxthen = GetFXDatum($dbh, $pdate->{$key}, $fx->{$name});
@@ -410,6 +413,7 @@ sub display_longstatus {
  	$return = (($prices->{$name} * $fxnow) / ($cost->{$key} * $fxthen) - 1)
 	  * 100 * Sign($shares->{$key});
  	# annualise if held longer than > 1 year
+#	perl >= 5.12 alread comforted as to $daysheld
 	$return *= 365 / $daysheld if ($daysheld > 365);
 	# weigh returns by the invested amount, not the current value
 	# NB this omits possible changes in the FX rate
@@ -418,6 +422,8 @@ sub display_longstatus {
 	$assetbase += $invested;
       }
     }
+#	comfort perl >= 5.12, was previously fixed out of this scope
+    if (! defined $daysheld ) {$daysheld = 0 ; }
     printf("%*s %6d   %3s %8.2f   %3s %10.2f  %s %s\n", 
 	   -18, substr($name,0,17), 
 	   $shares->{$key},  


### PR DESCRIPTION
…ing noise

Nothing major, but send along cutting the clutter

Still not working: beancounter backpopulate --prevdate $STARTDT (symbol ...)